### PR TITLE
add shebang and rename to activate.sh

### DIFF
--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 python -m venv .venv
 chmod +x .venv/bin/activate
 source .venv/bin/activate


### PR DESCRIPTION
.bash is not commonly used compared to .sh, and shebangs is just common practice

this PR has NOT been tested